### PR TITLE
[WIP] leap.js を主として用いるように書き直した

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,5 +9,8 @@
 
       <script type="text/javascript" src="js/leap.js.js"></script>
 
+      <p><canvas id="sketch" width="480" height="480"></canvas></p>
+      <script type="text/javascript" src="js/sketch.js"></script>
+
     </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -7,9 +7,7 @@
     </head>
     <body>
 
-      <p><canvas id="sketch" width="800" height="800"></canvas></p>
-
-      <script type="text/javascript" src="js/sketch.js"></script>
+      <script type="text/javascript" src="js/leap.js.js"></script>
 
     </body>
   </html>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     </head>
     <body>
 
-      <script type="text/javascript" src="js/leap.js.js"></script>
+      <script type="text/javascript" src="js/leap.js"></script>
 
       <p><canvas id="sketch" width="480" height="480"></canvas></p>
       <script type="text/javascript" src="js/sketch.js"></script>

--- a/js/leap.js
+++ b/js/leap.js
@@ -1,0 +1,45 @@
+var isDrawing = false;
+var points = [];
+
+Leap.loop({enableGestures: true}, function(frame){
+    if (frame.hands.length <= 0) {
+	return;
+    }
+
+    if (keyTapped(frame)) {
+	console.log("keyTapped!");
+
+	if (!isDrawing) { // start gesture
+	    console.log("start gesture");
+	    points = [];
+	} else {          // end gesture
+	    console.log("end gesture");
+
+	    // 
+	}
+
+	isDrawing = !isDrawing;
+    }
+
+    var hand = frame.hands[0];
+    var finger = hand.indexFinger;
+    var point = getFingertip(finger);
+    points.push(point);
+});
+
+function getFingertip(finger) {
+    var point = {"x": finger.tipPosition[0],
+		 "y": finger.tipPosition[1],
+		 "z": finger.tipPosition[2]};
+    return point;
+}
+
+function keyTapped(frame) {
+    var gestures = frame.gestures;
+    for (var i = 0; i < gestures.length; i++) {
+	if (gestures[i].type == "keyTap") {
+	    return true;
+	}
+    }
+    return false;
+}

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -4,8 +4,8 @@ function sketchProc(processing) {
     processing.setup = function(){
 	processing.size(480, 480, processing.P3D);
 
-	processing.fill(processing.color(255, 0, 255));
-	processing.stroke(processing.color(255, 0, 0));
+	processing.fill(255);
+	processing.stroke(255);
 
 	count = 0;
     };

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -24,7 +24,7 @@ function sketchProc(processing) {
     function drawPoint(point) {
 	processing.pushMatrix();
 
-	processing.translate(point.x, -point.y, point.z);
+	processing.translate(point.x, point.y, point.z);
 	processing.sphere(12);
 
 	processing.popMatrix();

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -1,56 +1,35 @@
-// initialize leapmotion
-var controller = new Leap.Controller({
-    host: '127.0.0.1',
-    port: 6437,
-    enableGestures: true,
-    frameEventName: 'animationFrame',
-    useAllPlugins: true
-});
-controller.connect();
-
-
-var points = [];
-
 function sketchProc(processing) {
+    var count;
+
     processing.setup = function(){
-	processing.size(600, 600, processing.P3D);
+	processing.size(480, 480, processing.P3D);
 
 	processing.fill(processing.color(255, 0, 255));
 	processing.stroke(processing.color(255, 0, 0));
 
+	count = 0;
+    };
+
+    processing.draw = function() {
+	drawPoint(points[count++]);
+
+	if (points.length <= count) {
+	    count = 0;
+
+	    processing.background(0);
+	}
     };
 
 
-    processing.draw = function() {
-	processing.background(0);
-
-	var frame = controller.frame();
-	
-	if(frame.hands.length == 0) {
-	    return;
-	}
-	console.log(frame.hands.length);
-
-	var hand = frame.hands[0];
-	var index = hand.indexFinger;
-	var x = index.tipPosition[0];
-	var y = index.tipPosition[1];
-	var z = index.tipPosition[2];
-	console.log("x: " + x, ", y: ", + y + ", z: " + z);
-
+    function drawPoint(point) {
 	processing.pushMatrix();
 
-	processing.translate(processing.width/2, processing.height, 0);
-	processing.translate(x, -y, z);
-
+	processing.translate(point.x, -point.y, point.z);
 	processing.sphere(12);
 
 	processing.popMatrix();
-    };
+    }
 }
 
-
 var canvas = document.getElementById("sketch");
-// attaching the sketchProc function to the canvas
 var p = new Processing(canvas, sketchProc);
-// p.exit(); to detach it

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -17,13 +17,14 @@ function sketchProc(processing) {
 	    return;
 	}
 
-	drawPoint(points[count++]);
 
 	if (points.length <= count) {
 	    count = 0;
 
 	    processing.background(0);
 	}
+
+	drawPoint(points[count++]);
     };
 
 

--- a/js/sketch.js
+++ b/js/sketch.js
@@ -11,6 +11,12 @@ function sketchProc(processing) {
     };
 
     processing.draw = function() {
+	if (points.length <= 0) {
+	    processing.background(0);
+
+	    return;
+	}
+
 	drawPoint(points[count++]);
 
 	if (points.length <= count) {


### PR DESCRIPTION
今まで書いてたコードでは、processing.js で処理を記述し、そこから leap.js を用いて leapmotion の状態を取得するようになっていた。

しかし、よくよく考えてみると必要なことは、processing が得意とするリッチなビジュアライズではない (よね？)。
そのため、leap.js を主として用い、processing.js には点列データの描画だけを行わせるようにした。

なお、手元に leapmotion がないため、実機でのテストはしていない。
参考程度にどうぞ。
