### PR TITLE
points を正規化してみた

### DIFF
--- a/src/test/normalize.js
+++ b/src/test/normalize.js
@@ -44,19 +44,3 @@ console.log(pointsZ);
 
 var normalizedZ = normalize(pointsZ);
 console.log(normalizedZ);
-
-
-function setNormalizeArray(arrayX,arrayY,arrayZ){
-    var arrayN =[];
-    for (var i = 0; i < arrayX.length; i++) {
-	arrayN.push({
-	    x: arrayX[i],
-	    y: arrayY[i],
-	    z: arrayZ[i]
-	});
-    }
-    return arrayN;
-}
-
-var ts_Q =setNormalizeArray(normalizedX,normalizedY,normalizedZ);
-console.log(ts_Q);

--- a/src/test/normalize.js
+++ b/src/test/normalize.js
@@ -32,11 +32,11 @@ function normalize(arrayX, arrayY) {
     
     var nyarray =[];
     for (var j = 0; j < arrayY.length; j++) {
-	var nvy = (arrayY[j] - minY) / max;
+	var nvy = (arrayY[i] - minY) / max;
 	nxarray.push(nvy);
     }    
     
-    return {x:nxarray, y:nyarray};
+    return nxarray, nyarray;
 };
 
 function extractAxis(points, axis) {
@@ -59,8 +59,7 @@ console.log(pointsX);
 var pointsY = extractAxis(points, 'y');
 console.log(pointsY);
 var normalized = normalize(pointsX, pointsY);
-console.log(normalized.x);
-console.log(normalized.y);
+console.log(normalized);
 
 
 
@@ -96,5 +95,5 @@ function setNormalizeArray(arrayX,arrayY,arrayZ){
     return arrayN;
 }
 
-var ts_Q =setNormalizeArray(normalized.x,normalized.y,zclear);
+var ts_Q =setNormalizeArray(normalized,zclear);
 console.log(ts_Q);

--- a/src/test/normalize.js
+++ b/src/test/normalize.js
@@ -1,46 +1,62 @@
-// array: array of number
-// e.g. [1, 2, 3]
-function normalize(array) {
-    var max = Math.max.apply(null, array);
-    var min = Math.min.apply(null, array);
-
-    var narray = [];
-    for (var i = 0; i < array.length; i++) {
-	var nv = (array[i] - min) / (max - min);
-	narray.push(nv);
-    }
-    return narray;
+// value を min から max で正規化
+// processing の map(value, min, max, 0, 1) と同じと考えればよし
+function normalize(value, min, max) {
+    return (value - min) / (max - min);
 };
 
+// points を min から max で正規化
+function normalizePoints(points) {
+    var d = points.map(function(d) { return [d.x, d.y, d.z]; });
+    var ary = Array.prototype.concat.apply([], d);
+    var min = Math.min.apply(null, ary);
+    var max = Math.max.apply(null, ary);
 
-function extractAxis(points, axis) {
-    return points.map(function(e) { return e[axis]; });
+    var npoints = [];
+    for (var i = 0; i < points.length; i++) {
+	var p = points[i];
+	var np = {
+	    x: normalize(p.x, min, max),
+	    y: normalize(p.y, min, max),
+	    z: normalize(p.z, min, max)
+	};
+
+	npoints.push(np);
+    }
+
+    return npoints;
 }
 
 
+console.log('points');
 var points = [
     {x: 1, y: 2, z: 3},
     {x: 10, y: 20, z: 30},
     {x: 100, y: 200, z: 300}
 ];
-
-
 console.log(points);
+console.log();
 
-var pointsX = extractAxis(points, 'x');
-console.log(pointsX);
+console.log('Convert to 2 dimensional array');
+var d = points.map(function(d) { return [d.x, d.y, d.z]; });
+console.log(d);
+console.log();
 
-var normalizedX = normalize(pointsX);
-console.log(normalizedX);
+console.log('Flatten');
+d = Array.prototype.concat.apply([], d);
+console.log(d);
+console.log();
 
-var pointsY = extractAxis(points, 'y');
-console.log(pointsY);
+console.log('min');
+var min = Math.min.apply(null, d);
+console.log(min);
+console.log();
 
-var normalizedY = normalize(pointsY);
-console.log(normalizedY);
+console.log('max');
+var max = Math.max.apply(null, d);
+console.log(max);
+console.log();
 
-var pointsZ = extractAxis(points, 'z');
-console.log(pointsZ);
-
-var normalizedZ = normalize(pointsZ);
-console.log(normalizedZ);
+console.log('Normalize points');
+var normalizedPoints = normalizePoints(points);
+console.log(normalizedPoints);
+console.log();

--- a/src/test/normalize.js
+++ b/src/test/normalize.js
@@ -1,43 +1,17 @@
 // array: array of number
 // e.g. [1, 2, 3]
-// function normalize(array) {
-//     var max = Math.max.apply(null, array);
-//     var min = Math.min.apply(null, array);
+function normalize(array) {
+    var max = Math.max.apply(null, array);
+    var min = Math.min.apply(null, array);
 
-//     var narray = [];
-//     for (var i = 0; i < array.length; i++) {
-// 	var nv = (array[i] - min) / (max - min);
-// 	narray.push(nv);
-//     }
-//     return narray;
-// };
-function normalize(arrayX, arrayY) {
-    var maxX = Math.max.apply(null, arrayX);
-    var minX = Math.min.apply(null, arrayX);
-
-    var maxY = Math.max.apply(null, arrayY);
-    var minY = Math.min.apply(null, arrayY);
-    var max;
-    if((maxX - minX) > (maxY - minY)){
-	max = maxX - minX;
-    }else{
-	max = maxY - minY;
+    var narray = [];
+    for (var i = 0; i < array.length; i++) {
+	var nv = (array[i] - min) / (max - min);
+	narray.push(nv);
     }
-    
-    var nxarray = [];
-    for (var i = 0; i < arrayX.length; i++) {
-	var nvx = (arrayX[i] - minX) / max;
-	nxarray.push(nvx);
-    }
-    
-    var nyarray =[];
-    for (var j = 0; j < arrayY.length; j++) {
-	var nvy = (arrayY[i] - minY) / max;
-	nxarray.push(nvy);
-    }    
-    
-    return nxarray, nyarray;
+    return narray;
 };
+
 
 function extractAxis(points, axis) {
     return points.map(function(e) { return e[axis]; });
@@ -56,32 +30,21 @@ console.log(points);
 var pointsX = extractAxis(points, 'x');
 console.log(pointsX);
 
+var normalizedX = normalize(pointsX);
+console.log(normalizedX);
+
 var pointsY = extractAxis(points, 'y');
 console.log(pointsY);
-var normalized = normalize(pointsX, pointsY);
-console.log(normalized);
 
+var normalizedY = normalize(pointsY);
+console.log(normalizedY);
 
+var pointsZ = extractAxis(points, 'z');
+console.log(pointsZ);
 
-// var normalizedY = normalize(pointsY);
-// console.log(normalizedY);
+var normalizedZ = normalize(pointsZ);
+console.log(normalizedZ);
 
-
-// var normalizedZ = normalize(pointsZ);
-// console.log(normalizedZ);
-
-function clear(data){
-    var n = data.length;
-    var d = [];
-    for (var i = 0; i < n; i++) {
-	d.push(0);
-    }
-    return d;
-}
- var pointsZ = extractAxis(points, 'z');
- console.log(pointsZ);
-
-var zclear = clear(pointsZ);
 
 function setNormalizeArray(arrayX,arrayY,arrayZ){
     var arrayN =[];
@@ -95,5 +58,5 @@ function setNormalizeArray(arrayX,arrayY,arrayZ){
     return arrayN;
 }
 
-var ts_Q =setNormalizeArray(normalized,zclear);
+var ts_Q =setNormalizeArray(normalizedX,normalizedY,normalizedZ);
 console.log(ts_Q);


### PR DESCRIPTION
やったこと
- points から min と max を抜き出す
  - points を二次元配列に
  - 二次元配列を一次元配列に
  - Math.max.apply() で前と同様に、min も同様
- normalize() を修正
  - processing の [norm()](https://processing.org/reference/norm_.html) と同じ感じにした
  - processing の map(value, max, min, 0, 1) と同じ
- points を nomalize する関数を書く
  - normalizePoints()

出力内容とコードを比べて、何をしているのか参考にするとよい。

```
otknoy:leap_practice otknoy$ node src/test/normalize.js                                                                                                                                        
points
[ { x: 1, y: 2, z: 3 },
  { x: 10, y: 20, z: 30 },
  { x: 100, y: 200, z: 300 } ]

Convert to 2 dimensional array
[ [ 1, 2, 3 ], [ 10, 20, 30 ], [ 100, 200, 300 ] ]

Flatten
[ 1, 2, 3, 10, 20, 30, 100, 200, 300 ]

min
1

max
300

Normalize points
[ { x: 0, y: 0.0033444816053511705, z: 0.006688963210702341 },
  { x: 0.030100334448160536,
    y: 0.06354515050167224,
    z: 0.09698996655518395 },
  { x: 0.3311036789297659, y: 0.6655518394648829, z: 1 } ]
```
